### PR TITLE
native code need upper case codec name

### DIFF
--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -318,6 +318,9 @@ class MediaInfo {
 						if (supported.getCodec()==="h264" && supported.hasParam("packetization-mode") && supported.getParam("packetization-mode")!=codec.getParam("packetization-mode","0"))
 							//Ignore
 							continue;
+						//If it is h264, check profile-level-id
+						if (supported.getCodec()==="h264" && supported.hasParam("profile-level-id") && codec.hasParam("profile-level-id") && supported.getParam("profile-level-id")!=codec.getParam("profile-level-id"))
+							continue;
 						//Clone codec
 						const cloned = supported.clone();
 						//Change payload type number

--- a/lib/SDPInfo.js
+++ b/lib/SDPInfo.js
@@ -545,7 +545,7 @@ class SDPInfo
 					//Add rtmpmap
 					md.rtp.push({
 						payload	: codec.getType(),
-						codec	: codec.getCodec(),
+						codec	: codec.getCodec().toUpperCase(),
 						rate	: 90000
 					});
 				} else {


### PR DESCRIPTION
This can fix  https://github.com/medooze/media-server-node/issues/44 

Have tested with brower and native code.