### PR TITLE
Fix getFirstTrack

### DIFF
--- a/lib/StreamInfo.js
+++ b/lib/StreamInfo.js
@@ -82,7 +82,7 @@ class StreamInfo {
 		for(let track of this.tracks.values())
 		{
 			if (track.getMedia().toLowerCase()===media.toLowerCase())
-				return this.track;
+				return track;
 		}
 		return this.null;
 	}


### PR DESCRIPTION
StreamInfo::getFirstTrack returns `undefined`
There is no track property.
```javascript
getFirstTrack(media) {
    for(let track of this.tracks.values())
        {
            if (track.getMedia().toLowerCase()===media.toLowerCase())
                return this.track;
        }
        return this.null;
    }
```
Please, take a look.