### PR TITLE
focus iceUfrag and icePwd to string

### DIFF
--- a/lib/SDPInfo.js
+++ b/lib/SDPInfo.js
@@ -1058,8 +1058,8 @@ SDPInfo.parse = function(string)
 		const mediaInfo = new MediaInfo(mid,media);
 
 		//Get ICE info
-		const ufrag = md.iceUfrag;
-		const pwd = md.icePwd;
+		const ufrag = String(md.iceUfrag);
+		const pwd = String(md.icePwd);
 
 		//Create iceInfo
 		sdpInfo.setICE(new ICEInfo(ufrag,pwd));


### PR DESCRIPTION
When iceUfrag in sdp appears in the form of **a=ice-ufrag:123456789**, **sdp-transform** library will parse iceUfrag to number type. 
It will cause **media-server-node** use the ufrag to create transport error. 
Because the ufrag is a number, **properties.SetProperty("ice.localUsername", this.local.ice.getUfrag())** must call C++ method: **void SetProperty(const char* key,int intval)**. 
But the js number type maybe be beyond the range of **int**(overflow). And It will cause stun request USERNAME error.
I have captured the error use tcpdump when I test **media-server-node** connect each other.
![image](https://user-images.githubusercontent.com/20473768/63908321-62c8cf80-ca51-11e9-9431-49a156240f91.png)

