### PR TITLE
Limit files that get published on NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Minimal SDP information semantic data model and parsing tools",
   "main": "index.js",
   "types": "./semantic-sdp.d.ts",
+  "files": [
+    "lib",
+    "index.js",
+    "semantic-sdp.d.ts"
+  ],
   "scripts": {
     "test": "test/example.js",
     "docs": "documentation build lib/SDPInfo.js lib/*.js --shallow -o docs -f html"


### PR DESCRIPTION
Some extra files like license, readme and package.json itself are included automatically and don't need to be listed explicitly.

Fixes #17