### PR TITLE
fix: Start extensions ids from 1 instead of 0 according to the spec.

### DIFF
--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -482,10 +482,15 @@ MediaInfo.create = function(type,supported)
 				 mediaInfo.setCodecs(supported.codecs);
 			 }
 		 }
-		//Add extensions
-		for (let id = 1; supported.extensions && id<supported.extensions.length; ++id)
-			//Add to answer
-			mediaInfo.addExtension(id, supported.extensions[id]);
+    //Add extensions
+    if (supported.extensions) {
+      let id = 1; // Extensions ids MUST NOT be 0 or 15 according to RFC 8285
+      for (let extension of supported.extensions) {
+        if (id === 15) id++;
+        //Add to answer
+        mediaInfo.addExtension(id++, extension);
+      }
+    }
        } else {
 	       //Inactive
 	       mediaInfo.setDirection(Direction.INACTIVE);

--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -483,7 +483,7 @@ MediaInfo.create = function(type,supported)
 			 }
 		 }
 		//Add extensions
-		for (let id = 0; supported.extensions && id<supported.extensions.length; ++id)
+		for (let id = 1; supported.extensions && id<supported.extensions.length; ++id)
 			//Add to answer
 			mediaInfo.addExtension(id, supported.extensions[id]);
        } else {

--- a/test/mediainfo_extensions.js
+++ b/test/mediainfo_extensions.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const SemanticSDP = require('../index');
+
+const MediaInfo = SemanticSDP.MediaInfo;
+
+const capabilities = {
+  codecs: ['vp9'],
+  rtx: true,
+  simulcast: true,
+  rtcpfbs: [
+    { id: 'goog-remb' },
+    { id: 'ccm', params: ['fir'] },
+    { id: 'nack' },
+    { id: 'nack', params: ['pli'] },
+  ],
+  extensions: [
+    'urn:3gpp:video-orientation',
+    'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01',
+    'urn:ietf:params:rtp-hdrext:sdes:mid',
+    'urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id',
+    'urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id',
+    'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time',
+    'test:7',
+    'test:8',
+    'test:9',
+    'test:10',
+    'test:11',
+    'test:12',
+    'test:13',
+    'test:14',
+    'test:15',
+  ],
+};
+
+const media = MediaInfo.create('video', capabilities);
+
+const extensionIds = Array.from(media.extensions.keys());
+
+assert(!extensionIds.includes(0), 'Extension id MUST NOT be 0');
+assert(!extensionIds.includes(15), 'Extension id MUST NOT be 15');
+assert(extensionIds.length === 15, `Expected 15 extensions in total, found ${extensionIds.length}`)


### PR DESCRIPTION
According to the [RFC 8285](https://tools.ietf.org/html/rfc8285#page-12) value `0` is reserved for padding. Quote:
```
Each local identifier potentially used in the stream is mapped to an
extension identified by a URI using an attribute of the form:

  a=extmap:<value>["/"<direction>] <URI> <extensionattributes>

where
   o  <value> is the local identifier (ID) of this extension and is an
      integer in the valid range (0 is reserved for padding in both
      forms, and 15 is reserved in the one-byte header form, as noted
      above).
```
I actually bumped into it while attempting to send generic SDP created using [Endpoint#createOffer](https://medooze.github.io/media-server-node/#endpointcreateoffer).

Firefox fails to set a local description with extmap id=0, failing with the error: "Description contains invalid extension id 0 on level 0 which is unsupported until 2-byte rtp header extensions are supported in webrtc.org".