### PR TITLE
Fix inconsistent set and get codes types

### DIFF
--- a/semantic-sdp.d.ts
+++ b/semantic-sdp.d.ts
@@ -490,7 +490,7 @@ declare module 'semantic-sdp' {
      * Set codec map
      * @param {Map<Number,CodecInfo>} codecs - Map of codec info objecs
      */
-    setCodecs(codecs: {[id: number]: CodecInfo}): void;
+    setCodecs(codecs: Map<Number,CodecInfo>): void;
 
     /**
      * Get codec for payload type number
@@ -517,7 +517,7 @@ declare module 'semantic-sdp' {
      * Get all codecs in this media
      * @returns {Map<Number,CodecInfo>}
      */
-    getCodecs(): {[id: number]: CodecInfo};
+    getCodecs(): Map<Number,CodecInfo>;
 
     /**
      * Check if any of the codecs on the media description supports rtx


### PR DESCRIPTION
Fixed the set codes param type to match the actual type of the codes
attributes which is a Map instead of a normal object.