### PR TITLE
fix more typos

### DIFF
--- a/lib/CandidateInfo.js
+++ b/lib/CandidateInfo.js
@@ -17,8 +17,8 @@
 	 * @param {String} address
 	 * @param {Number} port
 	 * @param {String} type
-	 * @param {String} relAddr
-	 * @param {Number} relPort
+	 * @param {String} [relAddr]
+	 * @param {Number} [relPort]
 	 */
 	constructor(foundation, componentId, transport, priority, address, port, type, relAddr, relPort) {
 		this.foundation		= foundation;
@@ -138,7 +138,7 @@
 
 	/**
 	 * Get the candidate related IP address for relfexive candidates
-	 * @returns {String}
+	 * @returns {String | undefined}
 	 */
 	getRelAddr() {
 		return this.relAddr;
@@ -146,7 +146,7 @@
 
 	/**
 	 * Get the candidate related IP port for relfexive candidates
-	 * @returns {Number}
+	 * @returns {Number | undefined}
 	 */
 	getRelPort() {
 		return this.relPort;

--- a/lib/CandidateInfo.js
+++ b/lib/CandidateInfo.js
@@ -18,7 +18,7 @@
 	 * @param {Number} port
 	 * @param {String} type
 	 * @param {String} relAddr
-	 * @param {String} relPort
+	 * @param {Number} relPort
 	 */
 	constructor(foundation, componentId, transport, priority, address, port, type, relAddr, relPort) {
 		this.foundation		= foundation;

--- a/lib/CodecInfo.js
+++ b/lib/CodecInfo.js
@@ -263,12 +263,12 @@ CodecInfo.expand = function(plain)
  * @param {Array<String>} names
  * @param {Boolean} rtx - Should we add rtx?
  * @param {Array<RTCPFeedbackInfoPlain>} rtcpfbs - RTCP feedback params
- * @returns {Map<String,CodecInfo>}
+ * @returns {Map<Number,CodecInfo>}
  */
 CodecInfo.MapFromNames = function(names,rtx,rtcpfbs)
 {
 	//The codec map
-	const codecs = new Map();
+	const codecs = /** @type {Map<Number,CodecInfo>} */ (new Map());
 
 	//Base dyn payload
 	let dyn = 96;
@@ -315,7 +315,7 @@ CodecInfo.MapFromNames = function(names,rtx,rtcpfbs)
 			codec.addParam(param[0].trim(),param[1].trim());
 		}
 		//Append
-		codecs.set(codec.getCodec().toLowerCase(),codec);
+		codecs.set(pt,codec);
 	}
 	//Get the map
 	return codecs;

--- a/lib/CodecInfo.js
+++ b/lib/CodecInfo.js
@@ -155,8 +155,12 @@ class CodecInfo {
 	 * @param {String} defaultValue default value if param is not found
 	 * @returns {String} 
 	 */
-	getParam(key,defaultValue) {
-		return this.hasParam(key) ? this.params[key] : "" + defaultValue;
+	getParam(key, defaultValue = undefined) {
+		if (this.hasParam(key))
+			return this.params[key];
+		if (defaultValue === undefined)
+			throw new Error(`param ${key} not found and no default value provided`)
+		return "" + defaultValue;
 	}
 	
 	/**

--- a/lib/CodecInfo.js
+++ b/lib/CodecInfo.js
@@ -261,8 +261,8 @@ CodecInfo.expand = function(plain)
  * Create a map of CodecInfo from codec names.
  * Payload type is assigned dinamically
  * @param {Array<String>} names
- * @param {Boolean} rtx - Should we add rtx?
- * @param {Array<RTCPFeedbackInfoPlain>} rtcpfbs - RTCP feedback params
+ * @param {Boolean} [rtx] - Should we add rtx?
+ * @param {Array<RTCPFeedbackInfoPlain>} [rtcpfbs] - RTCP feedback params
  * @returns {Map<Number,CodecInfo>}
  */
 CodecInfo.MapFromNames = function(names,rtx,rtcpfbs)

--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -514,7 +514,7 @@ class MediaInfo {
 /**
 * Helper factory for creating media info objects.
 * @param {MediaType} type - Media type
-* @param {SupportedMedia} supported - Supported media capabilities to be included on media info
+* @param {SupportedMedia} [supported] - Supported media capabilities to be included on media info
 * @returns {MediaInfo}
 */
 MediaInfo.create = function(type,supported)

--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -379,10 +379,10 @@ class MediaInfo {
 				for (let codec of this.codecs.values())
 				{
 					//If that codec is supported
-					if (supportedCodecs.has(codec.getCodec().toLowerCase()))
+					if (supportedCodecs.has(codec.getType()))
 					{
 						//Get supported code
-						const supported = supportedCodecs.get(codec.getCodec().toLowerCase());
+						const supported = supportedCodecs.get(codec.getType());
 						//If it is h264, check packetization mode
 						if (supported.getCodec()==="h264" && supported.hasParam("packetization-mode") && supported.getParam("packetization-mode")!=codec.getParam("packetization-mode","0"))
 							//Ignore

--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -378,11 +378,12 @@ class MediaInfo {
 				//For each codec on offer
 				for (let codec of this.codecs.values())
 				{
-					//If that codec is supported
-					if (supportedCodecs.has(codec.getType()))
+					//Try to find a matching supported codec
+					for (let supported of supportedCodecs.values())
 					{
-						//Get supported code
-						const supported = supportedCodecs.get(codec.getType());
+						//Codec name must match
+						if (supported.getCodec().toLowerCase() !== codec.getCodec().toLowerCase())
+							continue;
 						//If it is h264, check packetization mode
 						if (supported.getCodec()==="h264" && supported.hasParam("packetization-mode") && supported.getParam("packetization-mode")!=codec.getParam("packetization-mode","0"))
 							//Ignore
@@ -409,6 +410,7 @@ class MediaInfo {
 						cloned.addParams(codec.getParams());
 						//Add to answer
 						answer.addCodec(cloned);
+						break;
 					}
 				}
 			}

--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -573,7 +573,7 @@ MediaInfo.expand = function(plain)
 	//For each extension
 	for (let id in plain.extensions)
 		//Push cloned extension
-		mediaInfo.addExtension(id,plain.extensions[id]);
+		mediaInfo.addExtension(strictParseInt(id), plain.extensions[id]);
 
 	//For each codec
 	for (let i=0; plain.codecs && i<plain.codecs.length;++i)
@@ -607,5 +607,13 @@ MediaInfo.expand = function(plain)
 	//Done
 	return mediaInfo;
 };
+
+function strictParseInt(/** @type {string | number} */ x)
+{
+	const xStr = x.toString();
+	if (!/^\d+$/.test(xStr))
+		throw new Error(`invalid integer ${xStr}`);
+	return parseInt(xStr);
+}
 
 module.exports = MediaInfo;

--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -347,7 +347,7 @@ class MediaInfo {
 	 * - Will reverse the direction
 	 * - For each supported codec, it will change the payload type to match the offer and append it to the answer
 	 * - For each supported extension, it will append the ones present on the offer with the id offered
-	 * @param {SupportedMedia} supported - Supported codecs and extensions to be included on answer
+	 * @param {SupportedMedia} [supported] - Supported codecs and extensions to be included on answer
 	 * @returns {MediaInfo}
 	 */
 	answer(supported)

--- a/lib/SourceInfo.js
+++ b/lib/SourceInfo.js
@@ -62,7 +62,7 @@ class SourceInfo {
 
 	/**
 	 * Get associated stream id
-	 * @returns {Number}
+	 * @returns {String}
 	 */
 	getStreamId() {
 		return this.streamId;
@@ -78,7 +78,7 @@ class SourceInfo {
 
 	/**
 	 * Get associated track id
-	 * @returns {Number}
+	 * @returns {String}
 	 */
 	getTrackId() {
 		return this.trackId;

--- a/lib/TrackEncodingInfo.js
+++ b/lib/TrackEncodingInfo.js
@@ -74,7 +74,7 @@ class TrackEncodingInfo
 
 	/**
 	 * Get codec information for this encoding (if any)
-	 * @returns {Map<String,CodecInfo>}
+	 * @returns {Map<Number,CodecInfo>}
 	 */
 	getCodecs() {
 		return this.codecs;

--- a/lib/TrackEncodingInfo.js
+++ b/lib/TrackEncodingInfo.js
@@ -12,9 +12,9 @@ class TrackEncodingInfo
 	 * @constructor
 	 * @alias DTLSInfo
 	 * @param {String} id		- rid value
-	 * @param {Boolean} paused
+	 * @param {Boolean} [paused]
 	 */
-	constructor(id,paused)
+	constructor(id,paused=false)
 	{
 		//store properties
    		this.id		= id;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,6 +18,10 @@ export import Direction = require("./Direction");
 
 export type MediaType = 'audio'|'video'|'application';
 
+export type Capabilities = { [k in MediaType]?: SupportedMedia };
+
+export type SDPParams = { [k: string]: string };
+
 export interface SDPInfoParams {
 	// ICE info object
 	ice?: ICEInfo;
@@ -34,10 +38,6 @@ export interface SDPInfoParams {
 export interface RTCPFeedbackInfoPlain {
 	id: string;
 	params?: string[];
-}
-
-export interface Capabilities {
-	[k in MediaType]?: SupportedMedia;
 }
 
 export interface SupportedMedia {
@@ -57,10 +57,6 @@ export interface SupportedMedia {
 }
 
 export type DirectionPlain = 'sendrecv'|'sendonly'|'recvonly'|'inactive';
-
-export interface SDPParams {
-	[k: string]: string;
-}
 
 export interface CodecInfoPlain {
 	codec: string;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,10 +23,10 @@ export interface SDPInfoParams {
 	ice?: ICEInfo;
 	// DTLS info object
 	dtls?: DTLSInfo;
-	// Array of Ice candidates
+	// Array of ICE candidates
 	candidates?: CandidateInfo[];
 	// Capabilities for each media type
-	capabilities?: {[k in MediaType]?: SupportedMedia};
+	capabilities?: Capabilities;
 
 	crypto?: CryptoInfo;
 }
@@ -34,6 +34,10 @@ export interface SDPInfoParams {
 export interface RTCPFeedbackInfoPlain {
 	id: string;
 	params?: string[];
+}
+
+export interface Capabilities {
+	[k in MediaType]?: SupportedMedia;
 }
 
 export interface SupportedMedia {
@@ -52,13 +56,17 @@ export interface SupportedMedia {
 	dataChannel?: DataChannelInfoPlain;
 }
 
-export type DirectionPlain =|'sendrecv'|'sendonly'|'recvonly'|'inactive';
+export type DirectionPlain = 'sendrecv'|'sendonly'|'recvonly'|'inactive';
+
+export interface SDPParams {
+	[k: string]: string;
+}
 
 export interface CodecInfoPlain {
 	codec: string;
 	type: number;
 	rtx?: number;
-	params?: {[k: string]: string};
+	params?: SDPParams;
 	rtcpfbs?: RTCPFeedbackInfoPlain[];
 	channels?: number;
 }
@@ -70,7 +78,7 @@ export interface RIDInfoPlain {
 	id: string;
 	direction: DirectionPlain;
 	formats: number[];
-	params: {[k: string]: string};
+	params: SDPParams;
 }
 export interface SimulcastInfoPlain {
 	send: SimulcastStreamInfoPlain[][];
@@ -124,7 +132,7 @@ export interface TrackEncodingInfoPlain {
 	id: string;
 	paused: boolean;
 	codecs: {[id: string]: CodecInfoPlain};
-	params: {[k: string]: string};
+	params: SDPParams;
 }
 export interface TrackInfoPlain {
 	id: string;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -43,13 +43,14 @@ export interface RTCPFeedbackInfoPlain {
 export interface SupportedMedia {
 	// Map or codecInfo or list of strings with the supported codec names
 	codecs: Map<number, CodecInfo> | string[];
-	// List of strings with the supported extensions
-	extensions: Iterable<string>;
+	// List of strings with the supported extension URIs
+	extensions?: Iterable<string>;
 	// Simulcast is enabled
 	simulcast?: boolean;
-	// Supported RTCP feedback params
-	rtcpfbs: RTCPFeedbackInfoPlain[];
-	// If rtx is supported for codecs (only needed if passing codec names
+	// Supported RTCP feedback params (only used if passing codec names
+	// instead of CodecInfo)
+	rtcpfbs?: RTCPFeedbackInfoPlain[];
+	// If rtx is supported for codecs (only used if passing codec names
 	// instead of CodecInfo)
 	rtx?: boolean;
 	// Data channel is supported

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -56,7 +56,7 @@ export type DirectionPlain =|'sendrecv'|'sendonly'|'recvonly'|'inactive';
 
 export interface CodecInfoPlain {
 	codec: string;
-	type: string;
+	type: number;
 	rtx?: number;
 	params?: {[k: string]: string};
 	rtcpfbs?: RTCPFeedbackInfoPlain[];
@@ -97,7 +97,7 @@ export interface CandidateInfoPlain {
 	port: number;
 	type: string;
 	relAddr?: string;
-	relPort?: string;
+	relPort?: number;
 }
 export interface SourceGroupInfoPlain {
 	semantics: string;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,7 +38,7 @@ export interface RTCPFeedbackInfoPlain {
 
 export interface SupportedMedia {
 	// Map or codecInfo or list of strings with the supported codec names
-	codecs: Map<string, CodecInfo> | string[];
+	codecs: Map<number, CodecInfo> | string[];
 	// List of strings with the supported extensions
 	extensions: Iterable<string>;
 	// Simulcast is enabled


### PR DESCRIPTION
notably this fixes `CodecInfo.MapFromNames`, which was indexing the codecs by codec name instead of payload type.
it also causes `CodecInfo#getParam()` to **throw if getParam() was called without a default value, and it doesn't exist**.
also some other wrong types and minor typos/bugs.