### PR TITLE
add type alias

### DIFF
--- a/lib/CandidateInfo.js
+++ b/lib/CandidateInfo.js
@@ -1,4 +1,5 @@
 /** @typedef {import(".").CandidateInfoPlain} CandidateInfoPlain */
+/** @typedef {import(".").CandidateInfoLike} CandidateInfoLike */
 
 /**
  * ICE candidate information
@@ -156,7 +157,7 @@
 
 /**
  * Expands a plain JSON object containing an CandidateInfo
- * @param {CandidateInfoPlain | CandidateInfo} plain JSON object
+ * @param {CandidateInfoLike} plain JSON object
  * @returns {CandidateInfo} Parsed Candidate info
  */
 CandidateInfo.expand = function(plain)
@@ -181,7 +182,7 @@ CandidateInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an CandidateInfo or a CandidateInfo and clone it
- * @param {CandidateInfoPlain | CandidateInfo} plain JSON object or CandidateInfo
+ * @param {CandidateInfoLike} plain JSON object or CandidateInfo
  * @returns {CandidateInfo} Cloned Candidate info
  */
 CandidateInfo.clone = function(plain)

--- a/lib/CodecInfo.js
+++ b/lib/CodecInfo.js
@@ -1,6 +1,7 @@
 const RTCPFeedbackInfo = require("./RTCPFeedbackInfo");
 
 /** @typedef {import(".").CodecInfoPlain} CodecInfoPlain */
+/** @typedef {import(".").CodecInfoLike} CodecInfoLike */
 /** @typedef {import(".").RTCPFeedbackInfoPlain} RTCPFeedbackInfoPlain */
 
 /**
@@ -224,7 +225,7 @@ class CodecInfo {
 
 /**
  * Expands a plain JSON object containing an CodecInfo
- * @param {CodecInfoPlain | CodecInfo} plain JSON object
+ * @param {CodecInfoLike} plain JSON object
  * @returns {CodecInfo} Parsed Codec info
  */
 CodecInfo.expand = function(plain)
@@ -263,7 +264,7 @@ CodecInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an CodecInfo or a CodecInfo and clone it
- * @param {CodecInfoPlain | CodecInfo} plain JSON object or CodecInfo
+ * @param {CodecInfoLike} plain JSON object or CodecInfo
  * @returns {CodecInfo} Cloned CodecInfo
  */
 CodecInfo.clone = function(plain)

--- a/lib/CryptoInfo.js
+++ b/lib/CryptoInfo.js
@@ -1,4 +1,5 @@
 /** @typedef {import(".").CryptoInfoPlain} CryptoInfoPlain */
+/** @typedef {import(".").CryptoInfoLike} CryptoInfoLike */
 
 /**
  * SDES peer info
@@ -81,7 +82,7 @@ class CryptoInfo
 
 /**
  * Expands a plain JSON object containing an CryptoInfo
- * @param {CryptoInfoPlain | CryptoInfo} plain JSON object
+ * @param {CryptoInfoLike} plain JSON object
  * @returns {CryptoInfo} Parsed SDES info
  */
 CryptoInfo.expand = function(plain)
@@ -101,7 +102,7 @@ CryptoInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an CryptoInfo or a CryptoInfo and clone it
- * @param {CryptoInfoPlain | CryptoInfo} plain JSON object or CryptoInfo
+ * @param {CryptoInfoLike} plain JSON object or CryptoInfo
  * @returns {CryptoInfo} Cloned CryptoInfo
  */
 CryptoInfo.clone = function(plain)

--- a/lib/DTLSInfo.js
+++ b/lib/DTLSInfo.js
@@ -1,6 +1,7 @@
 const Setup		 = require("./Setup");
 
 /** @typedef {import(".").DTLSInfoPlain} DTLSInfoPlain */
+/** @typedef {import(".").DTLSInfoLike} DTLSInfoLike */
 
 /**
  * DTLS peer info
@@ -81,7 +82,7 @@ class DTLSInfo
 
 /**
  * Expands a plain JSON object containing an DTLSInfo
- * @param {DTLSInfoPlain | DTLSInfo} plain JSON object
+ * @param {DTLSInfoLike} plain JSON object
  * @returns {DTLSInfo} Parsed DTLS info
  */
 DTLSInfo.expand = function(plain)
@@ -100,7 +101,7 @@ DTLSInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an DTLSInfo or a DTLSInfo and clone it
- * @param {DTLSInfoPlain | DTLSInfo} plain JSON object or DTLSInfo
+ * @param {DTLSInfoLike} plain JSON object or DTLSInfo
  * @returns {DTLSInfo} Cloned DTLSInfo
  */
 DTLSInfo.clone = function(plain)

--- a/lib/DataChannelInfo.js
+++ b/lib/DataChannelInfo.js
@@ -1,4 +1,5 @@
 /** @typedef {import(".").DataChannelInfoPlain} DataChannelInfoPlain */
+/** @typedef {import(".").DataChannelInfoLike} DataChannelInfoLike */
 
 /**
  * DataChannel info
@@ -58,7 +59,7 @@ class DataChannelInfo
 
 /**
  * Expands a plain JSON object containing an DataChannelInfo
- * @param {DataChannelInfoPlain | DataChannelInfo} plain JSON object
+ * @param {DataChannelInfoLike} plain JSON object
  * @returns {DataChannelInfo} Parsed SDES info
  */
 DataChannelInfo.expand = function(plain)
@@ -76,7 +77,7 @@ DataChannelInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an DataChannelInfo or a DataChannelInfo and clone it
- * @param {DataChannelInfoPlain | DataChannelInfo} plain JSON object or DataChannelInfo
+ * @param {DataChannelInfoLike} plain JSON object or DataChannelInfo
  * @returns {DataChannelInfo} Cloned DataChannelInfo
  */
 DataChannelInfo.clone = function(plain)

--- a/lib/ICEInfo.js
+++ b/lib/ICEInfo.js
@@ -1,6 +1,7 @@
 const randomBytes = require('randombytes');
 
 /** @typedef {import(".").ICEInfoPlain} ICEInfoPlain */
+/** @typedef {import(".").ICEInfoLike} ICEInfoLike */
 
 /**
  * ICE information for a peer
@@ -121,7 +122,7 @@ ICEInfo.generate = function(lite)
 
 /**
  * Expands a plain JSON object containing an ICEInfo
- * @param {ICEInfoPlain | ICEInfo} plain JSON object
+ * @param {ICEInfoLike} plain JSON object
  * @returns {ICEInfo} Parsed ICE info
  */
 ICEInfo.expand = function(plain)
@@ -144,7 +145,7 @@ ICEInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an ICEInfo or a ICEInfo and clone it
- * @param {ICEInfoPlain | ICEInfo} plain JSON object or ICEInfo
+ * @param {ICEInfoLike} plain JSON object or ICEInfo
  * @returns {ICEInfo} Cloned ICEInfo
  */
 ICEInfo.clone = function(plain)

--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -9,6 +9,7 @@ const DataChannelInfo   = require ("./DataChannelInfo");
 /** @typedef {import(".").MediaType} MediaType */
 /** @typedef {import(".").SupportedMedia} SupportedMedia */
 /** @typedef {import(".").MediaInfoPlain} MediaInfoPlain */
+/** @typedef {import(".").MediaInfoLike} MediaInfoLike */
 
 /**
  * Media information (relates to a m-line in SDP)
@@ -542,7 +543,7 @@ MediaInfo.create = function(type,supported)
 
 /**
  * Expands a plain JSON object containing an MediaInfo
- * @param {MediaInfoPlain | MediaInfo} plain JSON object
+ * @param {MediaInfoLike} plain JSON object
  * @returns {MediaInfo} Parsed Media info
  */
 MediaInfo.expand = function(plain)
@@ -610,7 +611,7 @@ MediaInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an MediaInfo or a MediaInfo and clone it
- * @param {MediaInfoPlain | MediaInfo} plain JSON object or MediaInfo
+ * @param {MediaInfoLike} plain JSON object or MediaInfo
  * @returns {MediaInfo} Cloned MediaInfo
  */
 MediaInfo.clone = function(plain)

--- a/lib/RIDInfo.js
+++ b/lib/RIDInfo.js
@@ -1,6 +1,7 @@
 const DirectionWay		 = require("./DirectionWay");
 
 /** @typedef {import(".").RIDInfoPlain} RIDInfoPlain */
+/** @typedef {import(".").RIDInfoLike} RIDInfoLike */
 
 /**
  * RID info
@@ -133,7 +134,7 @@ class RIDInfo
 
 /**
  * Expands a plain JSON object containing an RIDInfo
- * @param {RIDInfoPlain | RIDInfo} plain JSON object
+ * @param {RIDInfoLike} plain JSON object
  * @returns {RIDInfo} Parsed RID info
  */
 RIDInfo.expand = function(plain)
@@ -162,7 +163,7 @@ RIDInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an RIDInfo or a RIDInfo and clone it
- * @param {RIDInfoPlain | RIDInfo} plain JSON object or RIDInfo
+ * @param {RIDInfoLike} plain JSON object or RIDInfo
  * @returns {RIDInfo} Cloned RIDInfo
  */
 RIDInfo.clone = function(plain)

--- a/lib/RTCPFeedbackInfo.js
+++ b/lib/RTCPFeedbackInfo.js
@@ -1,4 +1,5 @@
 /** @typedef {import(".").RTCPFeedbackInfoPlain} RTCPFeedbackInfoPlain */
+/** @typedef {import(".").RTCPFeedbackInfoLike} RTCPFeedbackInfoLike */
 
 /**
  * RTCP Feedback parameter
@@ -62,7 +63,7 @@ class RTCPFeedbackInfo
 
 /**
  * Expands a plain JSON object containing an CodecInfo
- * @param {RTCPFeedbackInfoPlain | RTCPFeedbackInfo} plain JSON object
+ * @param {RTCPFeedbackInfoLike} plain JSON object
  * @returns {RTCPFeedbackInfo} Parsed Codec info
  */
 RTCPFeedbackInfo.expand = function(plain)
@@ -80,7 +81,7 @@ RTCPFeedbackInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an RTCPFeedbackInfo or a RTCPFeedbackInfo and clone it
- * @param {RTCPFeedbackInfoPlain | RTCPFeedbackInfo} plain JSON object or RTCPFeedbackInfo
+ * @param {RTCPFeedbackInfoLike} plain JSON object or RTCPFeedbackInfo
  * @returns {RTCPFeedbackInfo} Cloned RTCPFeedbackInfo
  */
 RTCPFeedbackInfo.clone = function(plain)

--- a/lib/SDPInfo.js
+++ b/lib/SDPInfo.js
@@ -28,6 +28,7 @@ const DataChannelInfo	 = require("./DataChannelInfo");
 /** @typedef {import(".").MediaType} MediaType */
 /** @typedef {import(".").SDPInfoParams} SDPInfoParams */
 /** @typedef {import(".").SDPInfoPlain} SDPInfoPlain */
+/** @typedef {import(".").SDPInfoLike} SDPInfoLike */
 
 /**
  * SDP semantic info object
@@ -1186,7 +1187,7 @@ SDPInfo.create = function(params)
 	
 /**
  * Expands a plain JSON object containing an SDP INFO
- * @param {SDPInfoPlain | SDPInfo} plain JSON object
+ * @param {SDPInfoLike} plain JSON object
  * @returns {SDPInfo} Parsed SDP info
  */
 SDPInfo.expand = function(plain)
@@ -1244,7 +1245,7 @@ SDPInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an SDPInfo or a SDPInfo and clone it
- * @param {SDPInfoPlain | SDPInfo} plain JSON object or SDPInfo
+ * @param {SDPInfoLike} plain JSON object or SDPInfo
  * @returns {SDPInfo} Cloned SDPInfo
  */
 SDPInfo.clone = function(plain)

--- a/lib/SimulcastInfo.js
+++ b/lib/SimulcastInfo.js
@@ -2,6 +2,7 @@ const SimulcastStreamInfo	= require("./SimulcastStreamInfo");
 const DirectionWay		= require("./DirectionWay");
 
 /** @typedef {import(".").SimulcastInfoPlain} SimulcastInfoPlain */
+/** @typedef {import(".").SimulcastInfoLike} SimulcastInfoLike */
 /** @typedef {import(".").SimulcastStreamInfoPlain} SimulcastStreamInfoPlain */
 
 /**
@@ -101,7 +102,7 @@ class SimulcastInfo
 
 /**
  * Expands a plain JSON object containing an SimulcastInfo
- * @param {SimulcastInfoPlain | SimulcastInfo} plain JSON object
+ * @param {SimulcastInfoLike} plain JSON object
  * @returns {SimulcastInfo} Parsed Simulcast info
  */
 SimulcastInfo.expand = function(plain)
@@ -128,7 +129,7 @@ SimulcastInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an SimulcastInfo or a SimulcastInfo and clone it
- * @param {SimulcastInfoPlain | SimulcastInfo} plain JSON object or SimulcastInfo
+ * @param {SimulcastInfoLike} plain JSON object or SimulcastInfo
  * @returns {SimulcastInfo} Cloned SimulcastInfo
  */
 SimulcastInfo.clone = function(plain)

--- a/lib/SimulcastStreamInfo.js
+++ b/lib/SimulcastStreamInfo.js
@@ -1,4 +1,5 @@
 /** @typedef {import(".").SimulcastStreamInfoPlain} SimulcastStreamInfoPlain */
+/** @typedef {import(".").SimulcastStreamInfoLike} SimulcastStreamInfoLike */
 
 /**
  * Simulcast streams info
@@ -56,7 +57,7 @@ class SimulcastStreamInfo {
 
 /**
  * Expands a plain JSON object containing an SimulcastStreamInfo
- * @param {SimulcastStreamInfoPlain | SimulcastStreamInfo} plain JSON object
+ * @param {SimulcastStreamInfoLike} plain JSON object
  * @returns {SimulcastStreamInfo} Parsed SimulcastStream info
  */
 SimulcastStreamInfo.expand = function(plain)
@@ -74,7 +75,7 @@ SimulcastStreamInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an SimulcastStreamInfo or a SimulcastStreamInfo and clone it
- * @param {SimulcastStreamInfoPlain | SimulcastStreamInfo} plain JSON object or SimulcastStreamInfo
+ * @param {SimulcastStreamInfoLike} plain JSON object or SimulcastStreamInfo
  * @returns {SimulcastStreamInfo} Cloned SimulcastStreamInfo
  */
 SimulcastStreamInfo.clone = function(plain)

--- a/lib/SourceGroupInfo.js
+++ b/lib/SourceGroupInfo.js
@@ -1,4 +1,5 @@
 /** @typedef {import(".").SourceGroupInfoPlain} SourceGroupInfoPlain */
+/** @typedef {import(".").SourceGroupInfoLike} SourceGroupInfoLike */
 
 /**
  * Group of SSRCS info
@@ -66,7 +67,7 @@ class SourceGroupInfo {
 
 /**
  * Expands a plain JSON object containing an SourceGroupInfo
- * @param {SourceGroupInfoPlain | SourceGroupInfo} plain JSON object
+ * @param {SourceGroupInfoLike} plain JSON object
  * @returns {SourceGroupInfo} Parsed SourceGroup info
  */
 SourceGroupInfo.expand = function(plain)
@@ -84,7 +85,7 @@ SourceGroupInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an SourceGroupInfo or a SourceGroupInfo and clone it
- * @param {SourceGroupInfoPlain | SourceGroupInfo} plain JSON object or SourceGroupInfo
+ * @param {SourceGroupInfoLike} plain JSON object or SourceGroupInfo
  * @returns {SourceGroupInfo} Cloned SourceGroupInfo
  */
 SourceGroupInfo.clone = function(plain)

--- a/lib/SourceInfo.js
+++ b/lib/SourceInfo.js
@@ -1,4 +1,5 @@
 /** @typedef {import(".").SourceInfoPlain} SourceInfoPlain */
+/** @typedef {import(".").SourceInfoLike} SourceInfoLike */
 
 /**
  * Strem Source information
@@ -104,7 +105,7 @@ class SourceInfo {
 
 /**
  * Expands a plain JSON object containing an SourceInfo
- * @param {SourceInfoPlain | SourceInfo} plain JSON object
+ * @param {SourceInfoLike} plain JSON object
  * @returns {SourceInfo} Parsed Source info
  */
 SourceInfo.expand = function(plain)
@@ -126,7 +127,7 @@ SourceInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an SourceInfo or a SourceInfo and clone it
- * @param {SourceInfoPlain | SourceInfo} plain JSON object or SourceInfo
+ * @param {SourceInfoLike} plain JSON object or SourceInfo
  * @returns {SourceInfo} Cloned SourceInfo
  */
 SourceInfo.clone = function(plain)

--- a/lib/StreamInfo.js
+++ b/lib/StreamInfo.js
@@ -2,6 +2,7 @@ const TrackInfo = require("./TrackInfo");
 
 /** @typedef {import(".").MediaType} MediaType */
 /** @typedef {import(".").StreamInfoPlain} StreamInfoPlain */
+/** @typedef {import(".").StreamInfoLike} StreamInfoLike */
 
 /**
  * Media Stream information
@@ -126,7 +127,7 @@ class StreamInfo {
 
 /**
  * Expands a plain JSON object containing an StreamInfo
- * @param {StreamInfoPlain | StreamInfo} plain JSON object
+ * @param {StreamInfoLike} plain JSON object
  * @returns {StreamInfo} Parsed Stream info
  */
 StreamInfo.expand = function(plain)
@@ -155,7 +156,7 @@ StreamInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an StreamInfo or a StreamInfo and clone it
- * @param {StreamInfoPlain | StreamInfo} plain JSON object or StreamInfo
+ * @param {StreamInfoLike} plain JSON object or StreamInfo
  * @returns {StreamInfo} Cloned StreamInfo
  */
 StreamInfo.clone = function(plain)

--- a/lib/TrackEncodingInfo.js
+++ b/lib/TrackEncodingInfo.js
@@ -1,6 +1,7 @@
 const CodecInfo = require("./CodecInfo");
 
 /** @typedef {import(".").TrackEncodingInfoPlain} TrackEncodingInfoPlain */
+/** @typedef {import(".").TrackEncodingInfoLike} TrackEncodingInfoLike */
 
 /**
  * Simulcast encoding layer information for track
@@ -125,7 +126,7 @@ class TrackEncodingInfo
 
 /**
  * Expands a plain JSON object containing an TrackEncodingInfo
- * @param {TrackEncodingInfoPlain | TrackEncodingInfo} plain JSON object
+ * @param {TrackEncodingInfoLike} plain JSON object
  * @returns {TrackEncodingInfo} Parsed TrackEncoding info
  */
 TrackEncodingInfo.expand = function(plain)
@@ -153,7 +154,7 @@ TrackEncodingInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an TrackEncodingInfo or a TrackEncodingInfo and clone it
- * @param {TrackEncodingInfoPlain | TrackEncodingInfo} plain JSON object or TrackEncodingInfo
+ * @param {TrackEncodingInfoLike} plain JSON object or TrackEncodingInfo
  * @returns {TrackEncodingInfo} Cloned TrackEncodingInfo
  */
 TrackEncodingInfo.clone = function(plain)

--- a/lib/TrackInfo.js
+++ b/lib/TrackInfo.js
@@ -3,6 +3,7 @@ const TrackEncodingInfo = require("./TrackEncodingInfo");
 
 /** @typedef {import(".").MediaType} MediaType */
 /** @typedef {import(".").TrackInfoPlain} TrackInfoPlain */
+/** @typedef {import(".").TrackInfoLike} TrackInfoLike */
 /** @typedef {import(".").TrackEncodingInfoPlain} TrackEncodingInfoPlain */
 
 /**
@@ -238,7 +239,7 @@ class TrackInfo
 
 /**
  * Expands a plain JSON object containing an TrackInfo
- * @param {TrackInfoPlain | TrackInfo} plain JSON object
+ * @param {TrackInfoLike} plain JSON object
  * @returns {TrackInfo} Parsed Track info
  */
 TrackInfo.expand = function(plain)
@@ -278,7 +279,7 @@ TrackInfo.expand = function(plain)
 
 /**
  * Expands a plain JSON object containing an TrackInfo or a TrackInfo and clone it
- * @param {TrackInfoPlain | TrackInfo} plain JSON object or TrackInfo
+ * @param {TrackInfoLike} plain JSON object or TrackInfo
  * @returns {TrackInfo} Cloned TrackInfo
  */
 TrackInfo.clone = function(plain)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,6 +12,10 @@ export import StreamInfo = require("./StreamInfo");
 export import TrackInfo = require("./TrackInfo");
 export import RTCPFeedbackInfo = require("./RTCPFeedbackInfo");
 export import TrackEncodingInfo = require("./TrackEncodingInfo");
+export import RIDInfo = require("./RIDInfo");
+export import SimulcastInfo = require("./SimulcastInfo");
+export import SimulcastStreamInfo = require("./SimulcastStreamInfo");
+export import DataChannelInfo = require("./DataChannelInfo");
 export import Direction = require("./Direction");
 
 // Manually defined types
@@ -164,3 +168,23 @@ export interface SourceInfoPlain {
 	streamId: string;
 	trackId: string;
 }
+
+// TypeLike is an alias for "Type | TypePlain"
+
+export type RTCPFeedbackInfoLike = RTCPFeedbackInfo | RTCPFeedbackInfoPlain;
+export type CodecInfoLike = CodecInfo | CodecInfoPlain;
+export type StreamInfoLike = StreamInfo | StreamInfoPlain;
+export type RIDInfoLike = RIDInfo | RIDInfoPlain;
+export type SimulcastInfoLike = SimulcastInfo | SimulcastInfoPlain;
+export type MediaInfoLike = MediaInfo | MediaInfoPlain;
+export type CandidateInfoLike = CandidateInfo | CandidateInfoPlain;
+export type SourceGroupInfoLike = SourceGroupInfo | SourceGroupInfoPlain;
+export type ICEInfoLike = ICEInfo | ICEInfoPlain;
+export type DTLSInfoLike = DTLSInfo | DTLSInfoPlain;
+export type CryptoInfoLike = CryptoInfo | CryptoInfoPlain;
+export type TrackEncodingInfoLike = TrackEncodingInfo | TrackEncodingInfoPlain;
+export type TrackInfoLike = TrackInfo | TrackInfoPlain;
+export type SDPInfoLike = SDPInfo | SDPInfoPlain;
+export type SimulcastStreamInfoLike = SimulcastStreamInfo | SimulcastStreamInfoPlain;
+export type DataChannelInfoLike = DataChannelInfo | DataChannelInfoPlain;
+export type SourceInfoLike = SourceInfo | SourceInfoPlain;


### PR DESCRIPTION
that way we can write `CandidateInfoLike` instead of `CandidateInfoPlain | CandidateInfo`.
the `<thing>Like` naming convention is [common in the ecosystem](https://stackoverflow.com/questions/43712705/why-does-typescript-use-like-types).