### PR TITLE
make types more correct

### DIFF
--- a/lib/DataChannelInfo.js
+++ b/lib/DataChannelInfo.js
@@ -11,7 +11,7 @@ class DataChannelInfo
 	 * @constructor
 	 * @alias DataChannelInfo
 	 * @param {Number} port
-	 * @param {Number} maxMessageSize
+	 * @param {Number} [maxMessageSize]
 	 */
 	constructor(port,maxMessageSize)
 	{
@@ -50,7 +50,7 @@ class DataChannelInfo
 
 	/**
 	 * Get max message size
-	 * @returns {Number}
+	 * @returns {Number | undefined}
 	 */
 	getMaxMessageSize() {
 		return this.maxMessageSize;

--- a/lib/SDPInfo.js
+++ b/lib/SDPInfo.js
@@ -40,7 +40,7 @@ class SDPInfo
 	/**
 	 * @constructor
 	 * @alias SDPInfo
-	 * @param {Number} version SDP version attribute
+	 * @param {Number} [version] SDP version attribute
 	 */
 	constructor(version)
 	{
@@ -515,7 +515,6 @@ class SDPInfo
 	 */
 	answer(params) {
 		//Create local SDP info
-		//@ts-expect-error
 		const answer = new SDPInfo();
 
 		//Add ice 
@@ -1104,7 +1103,6 @@ class SDPInfo
 SDPInfo.create = function(params) 
 {
 	//Create local SDP info
-	//@ts-expect-error
 	const sdp = new SDPInfo();
 
 	//Add ice 
@@ -1280,7 +1278,6 @@ SDPInfo.parse = function(string)
 	const sdp = SDPTransform.parse(string);
 
  	//Create sdp info object
-	//@ts-expect-error
 	const sdpInfo = new SDPInfo();
 	
 	//Set version

--- a/lib/StreamInfo.js
+++ b/lib/StreamInfo.js
@@ -1,6 +1,6 @@
 const TrackInfo = require("./TrackInfo");
 
-/** @typedef {import(".").MediaType} MediaType */
+/** @typedef {import(".").TrackType} TrackType */
 /** @typedef {import(".").StreamInfoPlain} StreamInfoPlain */
 /** @typedef {import(".").StreamInfoLike} StreamInfoLike */
 
@@ -88,7 +88,7 @@ class StreamInfo {
 	}
 	/**
 	 * Get first track for the media type
-	 * @param {MediaType} media - Media type "audio"|"video"
+	 * @param {TrackType} media - Media type "audio"|"video"
 	 * @returns {TrackInfo}
 	 */
 	getFirstTrack(media) {

--- a/lib/TrackInfo.js
+++ b/lib/TrackInfo.js
@@ -1,7 +1,7 @@
 const SourceGroupInfo	= require("./SourceGroupInfo");
 const TrackEncodingInfo = require("./TrackEncodingInfo");
 
-/** @typedef {import(".").MediaType} MediaType */
+/** @typedef {import(".").TrackType} TrackType */
 /** @typedef {import(".").TrackInfoPlain} TrackInfoPlain */
 /** @typedef {import(".").TrackInfoLike} TrackInfoLike */
 /** @typedef {import(".").TrackEncodingInfoPlain} TrackEncodingInfoPlain */
@@ -15,7 +15,7 @@ class TrackInfo
 	/**
 	 * @constructor
 	 * @alias TrackInfo
-	 * @param {MediaType} media	- Media type "audio"|"video"
+	 * @param {TrackType} media	- Media type "audio"|"video"
 	 * @param {String} id		- Track id
 	 */
 	constructor(media,id) {
@@ -110,7 +110,7 @@ class TrackInfo
 
 	/**
 	 * Get media type
-	 * @returns {MediaType} - "audio"|"video"
+	 * @returns {TrackType} - "audio"|"video"
 	 */
 	getMedia() {
 		return this.media;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -20,6 +20,8 @@ export import Direction = require("./Direction");
 
 // Manually defined types
 
+export type TrackType = 'audio'|'video';
+
 export type MediaType = 'audio'|'video'|'application';
 
 export type Capabilities = { [k in MediaType]?: SupportedMedia };
@@ -28,15 +30,15 @@ export type SDPParams = { [k: string]: string };
 
 export interface SDPInfoParams {
 	/** ICE info object */
-	ice?: ICEInfo;
+	ice?: ICEInfoLike;
 	/** DTLS info object */
-	dtls?: DTLSInfo;
+	dtls?: DTLSInfoLike;
 	/** Array of ICE candidates */
-	candidates?: CandidateInfo[];
+	candidates?: CandidateInfoLike[];
 	/** Capabilities for each media type */
 	capabilities?: Capabilities;
 
-	crypto?: CryptoInfo;
+	crypto?: CryptoInfoLike;
 }
 
 export interface RTCPFeedbackInfoPlain {
@@ -46,7 +48,7 @@ export interface RTCPFeedbackInfoPlain {
 
 export interface SupportedMedia {
 	/** Map or codecInfo or list of strings with the supported codec names */
-	codecs: Map<number, CodecInfo> | string[];
+	codecs?: Map<number, CodecInfo> | string[];
 	/** List of strings with the supported extension URIs */
 	extensions?: Iterable<string>;
 	/** Simulcast is enabled */
@@ -59,6 +61,8 @@ export interface SupportedMedia {
 	dataChannel?: DataChannelInfoPlain;
 }
 
+export type SetupPlain = 'active'|'passive'|'actpass'|'inactive';
+export type DirectionWayPlain = 'send'|'recv';
 export type DirectionPlain = 'sendrecv'|'sendonly'|'recvonly'|'inactive';
 
 export interface CodecInfoPlain {
@@ -75,7 +79,7 @@ export interface StreamInfoPlain {
 }
 export interface RIDInfoPlain {
 	id: string;
-	direction: DirectionPlain;
+	direction: DirectionWayPlain;
 	formats: number[];
 	params: SDPParams;
 }
@@ -117,7 +121,7 @@ export interface ICEInfoPlain {
 	endOfCandidates?: boolean;
 }
 export interface DTLSInfoPlain {
-	setup: string;
+	setup?: SetupPlain;
 	hash: string;
 	fingerprint: string;
 }
@@ -135,7 +139,7 @@ export interface TrackEncodingInfoPlain {
 }
 export interface TrackInfoPlain {
 	id: string;
-	media: MediaType;
+	media: TrackType;
 	mediaId?: string;
 	ssrcs?: number[];
 	groups?: SourceGroupInfoPlain[];
@@ -159,7 +163,7 @@ export interface SimulcastStreamInfoPlain {
 
 export interface DataChannelInfoPlain {
 	port: number;
-	maxMessageSize: number;
+	maxMessageSize?: number;
 }
 
 export interface SourceInfoPlain {


### PR DESCRIPTION
this does not change the code, only tightens the types to better express the constraints.

 - TrackInfo#media is no longer allowed to be "application"
 - make the following fields optional:
   - SupportedMedia#codecs
   - DTLSInfoPlain#setup
   - DataChannelInfo#maxMessageSize
   - SDPInfo constructor "version" parameter
 - SDPInfoParams accepts Plain stuff too
 - RIDInfo#direction is DirectionWay, not Direction

I can take care of releasing once this is merged