### PR TITLE
feat: add support for creating offer with unified-plan like mids

### DIFF
--- a/lib/MediaInfo.js
+++ b/lib/MediaInfo.js
@@ -508,14 +508,25 @@ class MediaInfo {
 
 /**
 * Helper factory for creating media info objects.
+* @param {String} id - Media id
 * @param {MediaType} type - Media type
 * @param {SupportedMedia} [supported] - Supported media capabilities to be included on media info
 * @returns {MediaInfo}
 */
-MediaInfo.create = function(type,supported)
+MediaInfo.create = function(id,type,supported)
 {
+       //Support deprecated create(type,supported) 
+       if (!supported && Array.isArray(type))
+       {
+	       //Reallocate params
+	       // @ts-ignore
+	       supported = type;
+	        // @ts-ignore
+	       type = id;
+       }
+
        //Create new media
-       const mediaInfo = new MediaInfo(type,type);
+       const mediaInfo = new MediaInfo(id,type);
 
        if (supported)
        {

--- a/lib/SDPInfo.js
+++ b/lib/SDPInfo.js
@@ -1143,11 +1143,17 @@ SDPInfo.create = function(params)
 	let dyn = 96;
 	// Extensions ids MUST NOT be 0 or 15 according to RFC 8285
 	let id = 1; 
+	//Media id counter
+	let mids = 0;
 	//For each supported media type
 	for (const [mediaType, capEntry] of Object.entries(params.capabilities || {}))
 	{
 		//Create media
-		const media = MediaInfo.create(mediaType, capEntry);
+		const media = MediaInfo.create(
+			params.unified ? String(mids++) : mediaType,
+			/** @type MediaType */(mediaType),
+			capEntry
+		);
 		
 		//For each codec
 		for (const [codecId,codec] of media.getCodecs())

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,8 +35,10 @@ export interface SDPInfoParams {
 	candidates?: CandidateInfo[];
 	/** Capabilities for each media type */
 	capabilities?: Capabilities;
-
+	/** Crypto info objet*/
 	crypto?: CryptoInfo;
+	/** Generate unified like media ids*/
+	unified: boolean
 }
 
 export interface RTCPFeedbackInfoPlain {


### PR DESCRIPTION
Currently on `createOffer` we create the m-lines with the `mid` equal to the media type. This PR adds an option for using the m-line index instead, like done in unified plan